### PR TITLE
Update Imputation.cpp

### DIFF
--- a/src/Imputation.cpp
+++ b/src/Imputation.cpp
@@ -425,7 +425,7 @@ void Imputation::performImputation(HaplotypeSet &tHap,HaplotypeSet &rHap, String
         ifprintf(vcfdosepartial,"##filedate=%d.%d.%d\n",(now->tm_year + 1900),(now->tm_mon + 1) ,now->tm_mday);
         ifprintf(vcfdosepartial,"##source=Minimac3\n");
         ifprintf(vcfdosepartial,"##contig=<ID=%s>\n",rHap.finChromosome.c_str());
-        ifprintf(vcfdosepartial,"##FILTER=<ID=GENOTYPED>");
+        ifprintf(vcfdosepartial,"##FILTER=<ID=GENOTYPED>\n");
         if(GT)
                 ifprintf(vcfdosepartial,"##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n");
         if(tHap.AllMaleTarget)


### PR DESCRIPTION
Added new line output for line 428 since  ifprintf(vcfdosepartial,"##FILTER=<ID=GENOTYPED>"); was causing the lines to blend together.